### PR TITLE
Completed moving redundant functionality out of decrypt() and encrypt() 

### DIFF
--- a/project.cpp
+++ b/project.cpp
@@ -211,13 +211,11 @@ void encrypt(array<array<uint8_t, 12>, 20> subkeys){
   // A buffer is required for bytes to be read in order on a Little Endian machine
   array<uint8_t, 8>  buffer;
   buffer.fill(0);
-  array<uint16_t, 4>  plaintext_input;
-  plaintext_input.fill(0);
 
   int items_read = fread(&buffer, 1, 8, file_in);
   while(items_read > 0){
-    for(int i = 0; i < 4; i++)
-      plaintext_input[i] = (buffer[i*2] << 8 | buffer[i*2+1]);
+    array<uint16_t, 4>  plaintext_input = concat_chars_as_hex(buffer);
+
     array<uint16_t, 4> round_blocks = get_whitened_blocks(plaintext_input);
 
     for(int i = 0; i < 20; i++)

--- a/project.cpp
+++ b/project.cpp
@@ -7,7 +7,6 @@
 #include<bitset>
 #include<array>
 
-
 using namespace std;
 uint8_t unrotated_key[10] = {0};
 unsigned short w[4] = {0};
@@ -142,10 +141,8 @@ array<uint8_t, 10> get_key(){
   fclose(key_in);
 
   //Get rid if this if time -- original key should not be necessary, key is rotated back to beginning
-  for(int i = 0; i < 10; i++){
+  for(int i = 0; i < 10; i++)
     unrotated_key[i] = key[i];
-    cout << key[i] << endl;
-  }
 
   return key;
 }
@@ -208,11 +205,11 @@ void process_all_rounds(array<uint8_t, 8> buffer, array<array<uint8_t, 12>, 20> 
   array<uint16_t, 4> input = concat_chars_as_hex(buffer);
   array<uint16_t, 4> round_blocks = get_whitened_blocks(input);
 
-  if(option == 'd')
-    for(int i = 19; i > -1; i--)
-      process_single_round(round_blocks, subkeys, i);
-  else if(option == 'e')
+  if(option == 'e')
     for(int i = 0; i < 20; i++)
+      process_single_round(round_blocks, subkeys, i);
+  else if(option == 'd')
+    for(int i = 19; i > -1; i--)
       process_single_round(round_blocks, subkeys, i);
 
   array<uint16_t, 4> temp_blocks;
@@ -222,10 +219,10 @@ void process_all_rounds(array<uint8_t, 8> buffer, array<array<uint8_t, 12>, 20> 
 
   array<uint16_t, 4> processed_blocks = get_whitened_blocks(temp_blocks);
   
-  if(option == 'd')
-    write_file_as_ascii(processed_blocks);
-  else if(option == 'e')
+  if(option == 'e')
     write_file_as_hex(processed_blocks);
+  else if(option == 'd')
+    write_file_as_ascii(processed_blocks);
 
   buffer.fill(0);
 }
@@ -285,25 +282,16 @@ int main(int argc, char ** argv) {
     cout << "Must include e/d option." << endl;
     return -1;
   }
-
-  char option;
-
-  option = *argv[1];
-
-  //Open output file
+  char option = *argv[1];
 
   array<uint8_t, 10> key = get_key();
-
   array<array<uint8_t, 12>, 20> subkeys = gen_all_round_keys(key);
 
-  if(option == 'e'){
+  if(option == 'e')
     encrypt(subkeys);
-    return(0);
-  }
 
-  else{
+  else
     decrypt(subkeys);
 
-  }
-  return(0);
+  return 0;
 }

--- a/project.cpp
+++ b/project.cpp
@@ -261,17 +261,7 @@ void decrypt(array<array<uint8_t, 12>, 20> subkeys){
 
     //-------------BLOCK ENCRYPTION--------------//
     for(int i = 19; i > -1; i--){
-      unsigned short temp_r2 = round_blocks[0];
-      unsigned short temp_r3 = round_blocks[1];
-      unsigned short f0;
-      unsigned short f1;
-
-      F(subkeys, round_blocks[0], round_blocks[1], i, f0, f1);
-
-      round_blocks[0] = f0 ^ round_blocks[2];
-      round_blocks[1] = f1 ^ round_blocks[3];
-      round_blocks[2] = temp_r2;
-      round_blocks[3] = temp_r3;
+      process_round(round_blocks, subkeys, i);
     }
 
     for(int i = 0; i < 4; i++){


### PR DESCRIPTION
Encrypt() and decrypt() no longer have redundant code and act as a driver for process_all_rounds(), which takes as an argument "e" or "d" which determines which order to use the keys in and what format to write the file.