### PR TITLE
Passing keys by reference instead of value

### DIFF
--- a/project.cpp
+++ b/project.cpp
@@ -32,7 +32,7 @@ uint8_t get_byte(array<uint8_t, 10> key, int position){
   return key[i];
 }
 
-void rotate(array<uint8_t, 10> key){
+void rotate(array<uint8_t, 10>& key){
   //hold onto first bit that will be shifted out
   char rotate_bit = key[9] >> 7;
 
@@ -45,7 +45,7 @@ void rotate(array<uint8_t, 10> key){
   key[0] = key[0] << 1 | rotate_bit;
 }
 
-void gen_single_round_keys(array<uint8_t, 10> key, array<array<uint8_t, 12>, 20> subkeys, int round){
+void gen_single_round_keys(array<uint8_t, 10>& key, array<array<uint8_t, 12>, 20>& subkeys, int round){
   //find the 12 subkeys based on the current rotated key, rotate each round (12x)
   for(int i = 0; i < 12; i++){
     subkeys[round][i] = get_byte(key, 4*round + (i+4)%4);
@@ -54,7 +54,7 @@ void gen_single_round_keys(array<uint8_t, 10> key, array<array<uint8_t, 12>, 20>
 }
 
 
-array<array<uint8_t, 12>, 20> gen_all_round_keys(array<uint8_t, 10> key){  
+array<array<uint8_t, 12>, 20> gen_all_round_keys(array<uint8_t, 10>& key){  
   array<array<uint8_t, 12>, 20> subkeys;
   rotate(key);
 
@@ -214,8 +214,9 @@ void encrypt(){
   // A buffer is required for bytes to be read in order on a Little Endian machine
   array<uint8_t, 8>  buffer;
   buffer.fill(0);
-  array<uint8_t, 10> key = get_key();
-  array<array<uint8_t, 12>, 20> subkeys = gen_all_round_keys(key);
+  array<uint8_t, 10> start_key = get_key();
+  array<uint8_t, 10> key = start_key;
+  array<array<uint8_t, 12>, 20> subkeys = gen_all_round_keys(start_key);
 
   int items_read = fread(&buffer, 1, 8, file_in);
   while(items_read > 0){
@@ -236,8 +237,9 @@ void decrypt(){
   array<uint8_t, 8>  buffer;
   buffer.fill(0);
   unsigned int hex_digits;
-  array<uint8_t, 10> key = get_key();
-  array<array<uint8_t, 12>, 20> subkeys = gen_all_round_keys(key);
+  array<uint8_t, 10> start_key = get_key();
+  array<uint8_t, 10> key = start_key;
+  array<array<uint8_t, 12>, 20> subkeys = gen_all_round_keys(start_key);
 
 
   int items_read = fscanf(file_in, "%2x", &hex_digits);

--- a/project.cpp
+++ b/project.cpp
@@ -266,9 +266,6 @@ int main(int argc, char ** argv) {
   }
   char option = *argv[1];
 
-  //array<uint8_t, 10> key = get_key();
-  //array<array<uint8_t, 12>, 20> subkeys = gen_all_round_keys(key);
-
   if(option == 'e')
     encrypt();
 

--- a/project.cpp
+++ b/project.cpp
@@ -9,12 +9,8 @@
 
 using namespace std;
 uint8_t unrotated_key[10] = {0};
-unsigned short w[4] = {0};
-unsigned short r[4] = {0};
-unsigned short c[4] = {0};
-unsigned short y[4] = {0};
-uint8_t ftable [16][16] = 
-{{0xa3,0xd7,0x09,0x83,0xf8,0x48,0xf6,0xf4,0xb3, 0x21,0x15,0x78,0x99,0xb1,0xaf,0xf9},
+const array<array<uint8_t, 16>, 16> FTABLE = 
+{{{0xa3,0xd7,0x09,0x83,0xf8,0x48,0xf6,0xf4,0xb3, 0x21,0x15,0x78,0x99,0xb1,0xaf,0xf9},
   {0xe7,0x2d,0x4d,0x8a,0xce,0x4c,0xca,0x2e,0x52,0x95,0xd9,0x1e,0x4e,0x38,0x44,0x28},
   {0x0a,0xdf,0x02,0xa0,0x17,0xf1,0x60,0x68,0x12,0xb7,0x7a,0xc3,0xe9,0xfa,0x3d,0x53},
   {0x96,0x84,0x6b,0xba,0xf2,0x63,0x9a,0x19,0x7c,0xae,0xe5,0xf5,0xf7,0x16,0x6a,0xa2},
@@ -29,15 +25,15 @@ uint8_t ftable [16][16] =
   {0xad,0x04,0x23,0x9c,0x14,0x51,0x22,0xf0,0x29,0x79,0x71,0x7e,0xff,0x8c,0x0e,0xe2},
   {0x0c,0xef,0xbc,0x72,0x75,0x6f,0x37,0xa1,0xec,0xd3,0x8e,0x62,0x8b,0x86,0x10,0xe8},
   {0x08,0x77,0x11,0xbe,0x92,0x4f,0x24,0xc5,0x32,0x36,0x9d,0xcf,0xf3,0xa6,0xbb,0xac},
-  {0x5e,0x6c,0xa9,0x13,0x57,0x25,0xb5,0xe3,0xbd,0xa8,0x3a,0x01,0x05,0x59,0x2a,0x46}};
+  {0x5e,0x6c,0xa9,0x13,0x57,0x25,0xb5,0xe3,0xbd,0xa8,0x3a,0x01,0x05,0x59,0x2a,0x46}}};
 
 
-uint8_t get_byte(array<uint8_t, 10>&key, int position){
+uint8_t get_byte(array<uint8_t, 10> key, int position){
   int i = position % 10;
   return key[i];
 }
 
-void rotate(array<uint8_t, 10>& key){
+void rotate(array<uint8_t, 10> key){
   //hold onto first bit that will be shifted out
   char rotate_bit = key[9] >> 7;
 
@@ -50,7 +46,7 @@ void rotate(array<uint8_t, 10>& key){
   key[0] = key[0] << 1 | rotate_bit;
 }
 
-void gen_single_round_keys(array<uint8_t, 10>& key, array<array<uint8_t, 12>, 20>& subkeys, int round){
+void gen_single_round_keys(array<uint8_t, 10> key, array<array<uint8_t, 12>, 20> subkeys, int round){
   //find the 12 subkeys based on the current rotated key, rotate each round (12x)
   for(int i = 0; i < 12; i++){
     subkeys[round][i] = get_byte(key, 4*round + (i+4)%4);
@@ -59,9 +55,8 @@ void gen_single_round_keys(array<uint8_t, 10>& key, array<array<uint8_t, 12>, 20
 }
 
 
-array<array<uint8_t, 12>, 20> gen_all_round_keys(array<uint8_t, 10>& key){  
+array<array<uint8_t, 12>, 20> gen_all_round_keys(array<uint8_t, 10> key){  
   array<array<uint8_t, 12>, 20> subkeys;
-
   rotate(key);
 
   for(int i = 0; i < 20; i++){
@@ -72,23 +67,19 @@ array<array<uint8_t, 12>, 20> gen_all_round_keys(array<uint8_t, 10>& key){
 }
 
 
-uint8_t find_ftable(array<array<uint8_t, 12>, 20>& subkeys, unsigned char high_g, unsigned char low_g, int round, int key_index){
+uint8_t find_ftable(array<array<uint8_t, 12>, 20> subkeys, unsigned char high_g, unsigned char low_g, int round, int key_index){
   //generage 8 bytes that correspond to the index
-  uint8_t ftable_index = high_g ^ subkeys[round][key_index];
+  uint8_t index = high_g ^ subkeys[round][key_index];
 
+  //split FTABLE index into two parts: i and j to index into the ftable
+  unsigned int i = index >> 4;
+  unsigned int j = index  & 0x0f;
 
-  //split ftable index into two parts: i and j to index into the ftable
-  unsigned int i = ftable_index >> 4;
-  unsigned int j = ftable_index  & 0x0f;
-
-  //return the i,jth index of the ftable xor low_g
-  uint8_t freturn = ftable[i][j] ^ low_g;
-
-  return freturn;
-
+  //return the i,jth index of the FTABLE xor low_g
+  return FTABLE[i][j] ^ low_g;
 }
 
-unsigned short G(array<array<uint8_t, 12>, 20>& subkeys, unsigned short r0, int key_offset, int round){
+unsigned short G(array<array<uint8_t, 12>, 20> subkeys, unsigned short r0, int key_offset, int round){
   uint8_t g1 = short(r0 >> 8);
   uint8_t g2 = r0 & 0x00ff;
   uint8_t g3 = find_ftable(subkeys, g2, g1, round, key_offset + 0);
@@ -97,14 +88,10 @@ unsigned short G(array<array<uint8_t, 12>, 20>& subkeys, unsigned short r0, int 
   uint8_t g6 = find_ftable(subkeys, g5, g4, round, key_offset + 3);
 
   //concat g5 and g6 to return
-  unsigned short greturn = g5 << 8 | g6;
-
-  return greturn;
-
-  //uint8_t g3_index = 
+  return g5 << 8 | g6;
 }
 
-void F(array<array<uint8_t, 12>, 20>& subkeys, unsigned short block0, unsigned short block1, int round, unsigned short &f0, unsigned short &f1){  
+void F(array<array<uint8_t, 12>, 20> subkeys, unsigned short block0, unsigned short block1, int round, unsigned short &f0, unsigned short &f1){  
   unsigned short t0 = G(subkeys, block0, 0, round);
   unsigned short t1 = G(subkeys, block1, 4, round);
 
@@ -112,7 +99,7 @@ void F(array<array<uint8_t, 12>, 20>& subkeys, unsigned short block0, unsigned s
   f1 = ((2* t0) + t1 + (subkeys[round][10] << 8 | subkeys[round][11])) % 65536;
 }
 
-array<uint16_t, 2> get_f(array<array<uint8_t, 12>, 20>& subkeys, unsigned short block0, unsigned short block1, int round){ 
+array<uint16_t, 2> get_f(array<array<uint8_t, 12>, 20> subkeys, unsigned short block0, unsigned short block1, int round){ 
   array<uint16_t, 2> f;
   unsigned short t0 = G(subkeys, block0, 0, round);
   unsigned short t1 = G(subkeys, block1, 4, round);
@@ -181,7 +168,7 @@ void write_file_as_ascii(array<uint16_t, 4> buffer){
   fclose(file_out);
 }
 
-void process_single_round(array<uint16_t, 4>& round_blocks, array<array<uint8_t, 12>, 20> subkeys, int round){
+void process_single_round(array<uint16_t, 4> round_blocks, array<array<uint8_t, 12>, 20> subkeys, int round){
   uint16_t temp_r2 = round_blocks[0];
   uint16_t temp_r3 = round_blocks[1];
   array<uint16_t, 2> f = get_f(subkeys, round_blocks[0], round_blocks[1], round);
@@ -238,9 +225,7 @@ void encrypt(array<array<uint8_t, 12>, 20> subkeys){
   while(items_read > 0){
     array<uint16_t, 4>  plaintext_input = concat_chars_as_hex(buffer);
     array<uint16_t, 4> round_blocks = get_whitened_blocks(plaintext_input);
-
     process_all_rounds(buffer, subkeys, 'e');
-
     buffer.fill(0);
     items_read = fread(&buffer, 1, 8, file_in);
   }
@@ -267,9 +252,7 @@ void decrypt(array<array<uint8_t, 12>, 20> subkeys){
     }
 
     process_all_rounds(buffer, subkeys, 'd');
-
     buffer.fill(0);
-
     items_read = fscanf(file_in, "%2x", &hex_digits);
   }
 


### PR DESCRIPTION
Because the keys were passed by value, the rotated key was not updated in the calling function. This caused incorrect subkeys to be created. The algorithm did work because all subkeys were consistent in encrypt() and decrypt(). However, the encryption algorithm's work factor was significantly reduced. Likewise, the original key was not rotated back to the correct position, but since the same key was produced in encrypt() and decrypt(), the algorithm was able to produce the correct decryption after encrypting. These issues have both been fixed by copying the original key and passing the keys by reference.